### PR TITLE
fix: restore text selection highlight 

### DIFF
--- a/src/client/src/styles.scss
+++ b/src/client/src/styles.scss
@@ -2,7 +2,7 @@
  * @Author                : Jbristhuille<jbristhuille@gmail.com>             *
  * @CreatedDate           : 2023-05-30 11:59:22                              *
  * @LastEditors           : Jbristhuille<jbristhuille@gmail.com>             *
- * @LastEditDate          : 2024-09-05 11:58:44                              *
+ * @LastEditDate          : 2025-05-30 09:52:10                              *
  ****************************************************************************/
 
  @import '~quill/dist/quill.bubble.css';
@@ -70,11 +70,11 @@ a {
 }
 
 ::-moz-selection { /* Code for Firefox */
-  background: 0055ff;
+  background: #0055ff;
 }
 
 ::selection {
-  background: 0055ff;
+  background: #0055ff;
 }
 
 .ql-bubble.ql-disabled {


### PR DESCRIPTION
## ✨ Fix: Text selection highlight in ticket fields on Firefox

### 🐛 Description
This PR fixes an issue where text selection had **no visible highlight** in ticket input fields when using **Firefox**.  
The problem was caused by a malformed `::selection` CSS rule — the background color was missing the `#` prefix.

### ✅ Changes
- Fixed the `::selection` rule by correcting the background color syntax (`0055ff` → `#0055ff`)

### 🔍 Tested on
- Chrome ✅
- Firefox ✅

### 📎 Related ticket
`i6S-rXSo`
